### PR TITLE
TCTD-6-eXact-Townscape-replace-icon-controls-with-text-buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+/dist
+
+# development elearning session
+/public/session

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -4,48 +4,42 @@
   <div id="containerWrapper" :class="{ 'display-none': viewMode !== 'normal', 'editor-on': sessionConfig.editorOn === true  }" >
 
     <div class="stage-control-panel">
-
-      <button @click="stopStartAnimations()" class="hide svg-btn">
+      <button v-if="!sessionConfig.editorOn" @click="setSimpleViewMode()" class="hide controlBtn">
+        <span class="sr-only">Switch to accessible view</span>
+        <span class=""
+              aria-hidden="true"
+              >Accessible view
+              </span>
+      </button>
+      <button @click="stopStartAnimations()" class="controlBtn hide">
         <span class="sr-only">Toggle animations on and off</span>
-        <svg-icon v-if="animationsExist && animationsEnabled === true"
-                icon="stopAnimations"
+        <span v-if="animationsExist && animationsEnabled === true"
                 aria-hidden="true"
-                :color1="sessionConfig.stage.scrollButtonColour">
-                </svg-icon>
+                >Stop animations
+                </span>
 
-        <svg-icon v-if="animationsExist && animationsEnabled === false"
-                icon="startAnimations"
+        <span v-if="animationsExist && animationsEnabled === false"
                 aria-hidden="true"
-                :color1="sessionConfig.stage.scrollButtonColour">
-                </svg-icon>
+                >Start animations
+                </span>
       </button>
 
       <button v-if="!sessionConfig.editorOn"
               @click="toggleHotspotIndicator()"
-              class="hide svg-btn">
+              class="hide controlBtn">
         <span class="sr-only">Toggle hotspot indicator on and off</span>
-        <svg-icon v-if="hotspotIndicatorsEnabled === true"
-                icon="hideHotspots"
+        <span v-if="hotspotIndicatorsEnabled === true"
                 aria-hidden="true"
-                :color1="sessionConfig.stage.scrollButtonColour">
-                </svg-icon>
+                >Hide selectable areas
+                </span>
 
-        <svg-icon v-if="hotspotIndicatorsEnabled === false"
-                icon="showHotspots"
+        <span v-if="hotspotIndicatorsEnabled === false"
                 aria-hidden="true"
-                :color1="sessionConfig.stage.scrollButtonColour"
-                :color2="sessionConfig.stage.scrollButtonStrokeColour">
-                </svg-icon>
+                >Show selectable areas
+                </span>
       </button>
 
-      <button v-if="!sessionConfig.editorOn" @click="setSimpleViewMode()" class="hide svg-btn">
-        <span class="sr-only">Switch to accessible view</span>
-        <svg-icon class=""
-              icon="accessiblityOn"
-              aria-hidden="true"
-              :color1="sessionConfig.stage.scrollButtonColour">
-              </svg-icon>
-      </button>
+
       <button style="padding: 0.5em" v-if="sessionConfig.editorOn === true" @click="setVisibleModal('assetData')">Show Asset Info</button>
       <div v-if="sessionConfig.editorOn === true" class="xy-position">{{xPos}}%, {{yPos}}%
       </div>
@@ -540,8 +534,10 @@ export default defineComponent({
     z-index: 9999;
     position: relative;
 
-    .svg-btn {
-      width: 2%;
+    .controlBtn {
+      background-color:#fff;
+      border-radius:5px;
+      padding:1rem;
     }
   }
 

--- a/src/components/SmallView.vue
+++ b/src/components/SmallView.vue
@@ -6,10 +6,8 @@
     <div class="sm-view-wrapper">
       <div class="control-panel">
         <button class="switch-view" v-if="!sessionConfig.editorOn" @click="setDetailedViewMode()">
-          <div>
-            <span class="sr-only">Switch to standard view</span>
-            <div>Standard View</div>
-          </div>
+          <span class="sr-only">Switch to standard view</span>
+          <span class="" aria-hidden="true">Standard view </span>
         </button>
       </div>
       <ul style="padding: 0;">
@@ -79,6 +77,10 @@ export default defineComponent({
 
 .control-panel {
   margin-top: 1em;
+  button {
+    border-radius:5px;
+    padding:1rem;
+  }
 }
 
 @media only screen and (max-width: 1024px) {

--- a/src/components/SmallView.vue
+++ b/src/components/SmallView.vue
@@ -8,13 +8,7 @@
         <button class="switch-view" v-if="!sessionConfig.editorOn" @click="setDetailedViewMode()">
           <div>
             <span class="sr-only">Switch to standard view</span>
-            <svg-icon style="width: 3em;"
-              icon="accessiblityOff"
-              ariaLabel="Standard view"
-              :color1="sessionConfig.stage.scrollButtonColour">
-              </svg-icon>
-
-              <div>Standard View</div>
+            <div>Standard View</div>
           </div>
         </button>
       </div>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -22,7 +22,7 @@ a, label {
   color: $txt-color;
 }
 
-a { 
+a {
   text-decoration: none;
   &:hover {
     color: lighten($txt-color, 20);
@@ -93,14 +93,14 @@ button:-webkit-details-marker {
     .control-panel {
       margin-left: 0.5em;
     }
-  
+
     &>ul {
       list-style: none;
       li {
         border: 1px dashed #333;
         border-width: 0 0 1px 0;
         padding: 0.5em 0;
-  
+
         .icon {
             margin: 0.5em 1.3em 0.5em 0.5em;
             width: 3vw;
@@ -109,13 +109,13 @@ button:-webkit-details-marker {
             }
           }
       }
-  
+
       li:last-of-type {
          border: none;
       }
     }
   }
-  
+
 }
 
 .display-none#containerWrapper, .display-none#hotspotPageView, .display-none#smallHotspotPageView, .display-none#smallView, .display-none#smallLinkListView {
@@ -138,7 +138,7 @@ button:-webkit-details-marker {
   .sm-view {
     display: none;
   }
-  
+
   .display#smallView, .display#smallHotspotPageView, .display#smallLinkListView {
     display: block;
 
@@ -147,7 +147,7 @@ button:-webkit-details-marker {
       padding: 0;
     }
     .icon {
-     
+
       width: 50px;
     }
   }
@@ -173,10 +173,10 @@ a[target=_blank]::after {
 
   .breadcrumbs {
     a, a:visited {
-      color: $breadcrumb-link-color; 
+      color: $breadcrumb-link-color;
     }
   }
- 
+
 }
 
 button.hide {
@@ -199,6 +199,12 @@ button.hide {
   }
 }
 
+button.hide.controlBtn {
+  &:hover {
+    background: #ffeb3b;
+  }
+}
+
 
 .scroll-button {
   &:focus {
@@ -207,7 +213,7 @@ button.hide {
 }
 
 .linkText a {
-  
+
   &:focus {
     outline: $keyboard-focus-width $keyboard-focus-style $keyboard-focus-color;
   }
@@ -244,7 +250,7 @@ a.hotspot {
       transition: all 0.4s ease-in-out;
       transform: scale(1.2);
     }
-    
+
   }
 }
 
@@ -252,9 +258,9 @@ a.hotspot {
   ::v-deep a {
     text-decoration: underline;
     &:focus {
-      
+
       outline: $keyboard-focus-width $keyboard-focus-style $keyboard-focus-color;
-      
+
     }
     &:active {
       outline: none;
@@ -281,13 +287,13 @@ a.hotspot {
       }
 
     }
-    
+
   }
 }
 .small-view-link {
-  display: flex; 
-  flex-flow: row nowrap; 
-  justify-content: flex-start; 
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
   align-items: center;
 }
 


### PR DESCRIPTION
Replace the control buttons that appear top left on the opening screen with text label buttons as it was felt the icon buttons were not very intuitive. As part of this work, the Return to standard view button on the accessiblity view has also had its icon removed.

Note there will be another separate task to enable the learning designer to change the style of these control buttons via the online editor.