### PR TITLE
TCTD-8-eXact-Townscape-external-links-underlined-and-link-icon-recolour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+/dist
+
+# development elearning session
+/public/session

--- a/src/assets/img/new_window.svg
+++ b/src/assets/img/new_window.svg
@@ -1,1 +1,1 @@
-<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#666" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#000" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path></svg>

--- a/src/components/PopUpView.vue
+++ b/src/components/PopUpView.vue
@@ -390,6 +390,7 @@ export default defineComponent({
 .linkText {
   display: block;
   padding: 0.8em;
+  text-decoration:underline;
 }
 
 li.has-accordion {


### PR DESCRIPTION
On the standard view, add text decoration underline to all the links on the modal page (i.e the cotent with all the signposted links)

![image](https://user-images.githubusercontent.com/114067294/234546012-70e11294-bb7d-4df5-8ffd-139f614fbd0b.png)
