### PR TITLE
TCTD-7-fix-issue-with-link-page-content-being-cut-off-at-bottow

### DIFF
--- a/src/components/PopUpView.vue
+++ b/src/components/PopUpView.vue
@@ -293,6 +293,8 @@ export default defineComponent({
   display: flex;
   justify-content: center; /*centers items on the line (the x-axis by default)*/
   align-items: center; /*centers items on the cross-axis (y by default)*/
+
+  height:100%;
 }
 
 .modal__container {
@@ -302,15 +304,17 @@ export default defineComponent({
   background: transparent;
   overflow-x: auto;
 
-  &.small {
-    width: 25%;
-    height: 90%;
-  }
 
-  &.large {
-    width: 96vw;
-    height: 96vh;
-  }
+  //&.small {
+    //width: 25%;
+    //height: 90%;
+  //}
+
+  //&.large {
+    //width: 96vw;
+    //height: 96vh;
+  //}
+  height:100%;
 }
 
 .modal__header {
@@ -356,6 +360,8 @@ export default defineComponent({
   list-style: none;
   margin-top: 0.3em;
   text-align: left;
+  max-height: 60%;
+  overflow-y: auto;
 
   ul {
     padding: 0;


### PR DESCRIPTION
On the screen with the modal that contains the list of links, the content can get cut off when the screen is a certain size and the user is unable to view the cut off content. Need to amend so that a vertical scroll bar appears when the content is too long so that the user can scroll to the hidden content.