### PR TITLE
Add screenreader only H1 Tag to each of the landing pages

### DIFF
--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -63,7 +63,7 @@
     <div id="container"
          :class="{ 'drag-zone': sessionConfig.editorOn === true }"
          :style="{ width: sessionConfig.stage.width, height: sessionConfig.stage.height, backgroundColor: sessionConfig.stage.backgroundColor }">
-      <p class="sr-only">{{ sessionConfig.title }}</p>
+      <h1 class="sr-only">{{ sessionConfig.title }}</h1>
 
       <!-- background -->
       <div v-if="sessionConfig.stageBackground && sessionConfig.stageBackground.id !== ''"

--- a/src/components/HotspotPageView.vue
+++ b/src/components/HotspotPageView.vue
@@ -4,7 +4,7 @@
   <main id="hotspotPageView" style="position: absolute; left:0; top:0; width: 100%; height: 100%;" :style="{ backgroundColor: page.backgroundColor }"
         :class="{ 'display-none': viewMode !== 'normal', 'editor-on': sessionConfig.editorOn === true  }" >
     <div style="position: relative; height: 92%;">
-      <div class="sr-only">{{ page.name }}</div>
+      <h1 class="sr-only">{{ page.pageTitle }}</h1>
 
       <div class="page-image-container">
         <img :src="page.backgroundImgSrc" class="page-image" alt="" >

--- a/src/models/HotspotPage.ts
+++ b/src/models/HotspotPage.ts
@@ -4,6 +4,7 @@ import Link from "./Link";
 export default class HotspotPage {
   public id = "";
   public name = "";
+  public pageTitle = "";
   // RGBA - default black with no opacity
   public backgroundColor = "#fff";
   public iconColor1 = "#000";

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -175,6 +175,7 @@ export const store = createStore<State>({
           p.iconColor1 = configPage["@iconcolour"];
           p.iconColor2 = "#fff";
           p.iconColor3 = configPage["@iconcolour"];
+          p.pageTitle = configPage["@description"];
 
           configPage.components.forEach((c: any) => {
             // image inside stage asset


### PR DESCRIPTION
To ensure we meet accessibility requirements, add a screenreader only h1 to each of the landing pages using the Name field text value as the content of the h1 tag. 